### PR TITLE
Create package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.npm-relink.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "aframe-assets",
+  "version": "1.0.4",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "aframe-assets",
+  "version": "1.0.4",
+  "description": "Assets used in various A-Frame examples and boilerplates.",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aframevr/assets.git"
+  },
+  "keywords": [
+    "aframe"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/aframevr/assets/issues"
+  },
+  "homepage": "https://github.com/aframevr/assets#readme"
+}


### PR DESCRIPTION
The aframe core library [references fonts](https://github.com/aframevr/aframe/blob/master/src/components/text.js#L19) contained in this repo. In order to create Cordova compatibility, I need to include this package as an `npm` dependency of my Cordova-Aframe plugin. Thus a `package.json` is required.

Note: It would probably be better to bundle the fonts with the A-Frame package rather than refereeing a hard-coded CDN URL.